### PR TITLE
Fix syntax errors in JSON examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ plugins: [
     "runtime": "nodejs",
     "custom": {
         "webpack": {
-            "configPath": 'path/relative/to/project-path',
+            "configPath": "path/relative/to/project-path"
         }
     }
 }
@@ -96,7 +96,7 @@ In this case assume your component is named `foo` and your config `webpack.confi
     "runtime": "nodejs",
     "custom": {
         "webpack": {
-            "configPath": 'foo/webpack.config.js',
+            "configPath": "foo/webpack.config.js"
         }
     }
 }


### PR DESCRIPTION
First, thanks for bringing webpack to the serverless community!

Just a couple JSON fixes in the README that caused some syntax errors when I copy/pasted.
