### PR TITLE
support nodejs4.3 on lambda

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function getPlugin(ServerlessPlugin) {
       const func = this.S.state.getFunctions({ paths: [evt.options.path] })[0];
       const component = func.getComponent();
 
-      if (component.runtime === 'nodejs') {
+      if (component.runtime === 'nodejs' || 'nodejs4.3') {
         const projectPath = this.S.config.projectPath;
         const config = getConfig(projectPath, component, func);
 


### PR DESCRIPTION
aws released support for nodejs 4.3 support, serverless also added support, this pull request enables serverless-webpack-plugin on nodejs4.3

https://github.com/serverless/serverless/releases/tag/v0.5.3

https://aws.amazon.com/blogs/compute/node-js-4-3-2-runtime-now-available-on-lambda/
