### PR TITLE
node 4.3 fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function getPlugin(S) {
       const project = S.getProject();
       const func = project.getFunction(evt.options.name);
 
-      if (func.runtime === 'nodejs') {
+      if (func.runtime === 'nodejs' || 'nodejs4.3') {
         const projectPath = S.config.projectPath;
         const config = getConfig(
           projectPath,


### PR DESCRIPTION
aws released support for nodejs 4.3 support, serverless also added support, this pull request enables serverless-webpack-plugin on nodejs4.3

https://github.com/serverless/serverless/releases/tag/v0.5.3

https://aws.amazon.com/blogs/compute/node-js-4-3-2-runtime-now-available-on-lambda/

 fixed merge conflicts
