### PR TITLE
Build fails when building more than one function at a time

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function getPlugin(S) {
           const optimizedPath = path.join(pathDist, 'optimized');
           const optimizedModulesPath = path.join(optimizedPath, 'node_modules');
 
-          const webpackConfig = config.webpackConfig;
+          const webpackConfig = Object.assign({}, config.webpackConfig);
           const handlerName = func.getHandler().split('.')[0];
           const handlerFileName = `${handlerName}.${config.handlerExt}`;
 


### PR DESCRIPTION
I'm running `sls dash deploy` on my webpack-optimized functions, and when I choose to deploy only one it works fine, but two or more fail with an error about uploading an empty ZIP file.

It looks like it's because each Webpack build process uses the same config object - so when we overwrite the output path for one it actually changes the path for all. So I think all the functions try to build to the same directory, which is emptied before the other functions can read their output.

This is a simple change that just uses `Object.assign()` on the webpack config, so when we change `config.output` it is only reflected in the config for that function, not all of them.
