### PR TITLE
Fix broken 'handlerEntryPath'

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,9 +80,9 @@ module.exports = function getPlugin(S) {
           // override entry and output
           webpackConfig.context = path.dirname(func.getFilePath());
           if (Array.isArray(webpackConfig.entry)) {
-            webpackConfig.entry.push(path.join(pathDist, handlerEntryPath));
+            webpackConfig.entry.push(handlerEntryPath);
           } else {
-            webpackConfig.entry = path.join(pathDist,handlerEntryPath);
+            webpackConfig.entry = handlerEntryPath;
           }
 
           webpackConfig.output = {

--- a/index.js
+++ b/index.js
@@ -84,7 +84,6 @@ module.exports = function getPlugin(S) {
           } else {
             webpackConfig.entry = handlerEntryPath;
           }
-
           webpackConfig.output = {
             libraryTarget: 'commonjs',
             path: optimizedPath,

--- a/index.js
+++ b/index.js
@@ -75,15 +75,16 @@ module.exports = function getPlugin(S) {
           const webpackConfig = Object.assign({}, config.webpackConfig);
           const handlerName = func.getHandler().split('.')[0];
           const handlerFileName = `${handlerName}.${config.handlerExt}`;
-          const handlerEntryPath = `./${handlerFileName}`;
+          const handlerEntryPath = path.join(pathDist, handlerFileName);
 
           // override entry and output
           webpackConfig.context = path.dirname(func.getFilePath());
           if (Array.isArray(webpackConfig.entry)) {
-            webpackConfig.entry.push(handlerEntryPath);
+            webpackConfig.entry.push(path.join(pathDist, handlerEntryPath));
           } else {
-            webpackConfig.entry = handlerEntryPath;
+            webpackConfig.entry = path.join(pathDist,handlerEntryPath);
           }
+
           webpackConfig.output = {
             libraryTarget: 'commonjs',
             path: optimizedPath,


### PR DESCRIPTION
Use fully qualified path for the `handlerEntryPath` otherwise:
1. The temporary `_server_handler.js` file is created in local function folder rather than `_meta/_tmp/...`
2. If a function's handler references any parent folders (e.g. `handler: functions/auth/login/handler.handler`) during the packaging process, the handler imported from `_serverless_handler.js` is not in the same folder and therefore compilation fails (quietly, unless you debug) leaving the deployed package broken.

This change fixes that issue. Tested with both nested and non-nested `handler` settings.
