### PR TITLE
Fix: Full dependencies not installed for externals

### DIFF
--- a/lib/copyModules.js
+++ b/lib/copyModules.js
@@ -1,13 +1,27 @@
 'use strict';
 const path = require('path');
-const fs = require('fs-extra');
+const childProcess = require('child_process');
 const Promise = require('bluebird');
 
-const copy = Promise.promisify(fs.copy);
+const exec = Promise.promisify(childProcess.exec);
 
 module.exports = function copyModules(projectPath, moduleNames, dest) {
+  const pkg = require(path.join(projectPath, 'package.json'));
+
   return Promise.all(moduleNames.map(moduleName => {
-    const modulePath = path.join(projectPath, 'node_modules', moduleName);
-    return copy(modulePath, path.join(dest, moduleName));
+    const moduleVersion = pkg.dependencies[moduleName];
+
+    if (!moduleVersion) {
+      const error = new Error(`No module ${moduleName} found in package.json`);
+      return Promise.reject(error);
+    }
+
+    // Run 'npm install' on each module to get a full set of dependencies,
+    // not just the directly copied ones.
+    const opts = {
+      cwd: path.join(dest)
+    }
+
+    return exec(`npm install --production ${moduleName}@${moduleVersion}`, opts);
   }));
 };

--- a/lib/copyModules.js
+++ b/lib/copyModules.js
@@ -7,21 +7,16 @@ const exec = Promise.promisify(childProcess.exec);
 
 module.exports = function copyModules(projectPath, moduleNames, dest) {
   const pkg = require(path.join(projectPath, 'package.json'));
-
-  return Promise.all(moduleNames.map(moduleName => {
+  const modulesAndVersions = moduleNames.map(moduleName => {
     const moduleVersion = pkg.dependencies[moduleName];
+    return `${moduleName}@${moduleVersion}`;
+  });
+  const opts = {
+    cwd: path.join(dest)
+  };
+  const installString = modulesAndVersions.join(' ');
 
-    if (!moduleVersion) {
-      const error = new Error(`No module ${moduleName} found in package.json`);
-      return Promise.reject(error);
-    }
-
-    // Run 'npm install' on each module to get a full set of dependencies,
-    // not just the directly copied ones.
-    const opts = {
-      cwd: path.join(dest)
-    }
-
-    return exec(`npm install --production ${moduleName}@${moduleVersion}`, opts);
-  }));
+  // Run 'npm install' on each module to get a full set of dependencies,
+  // not just the directly copied ones.
+  return exec(`npm install --production ${installString}`, opts);
 };

--- a/lib/copyModules.js
+++ b/lib/copyModules.js
@@ -3,20 +3,29 @@ const path = require('path');
 const childProcess = require('child_process');
 const Promise = require('bluebird');
 
-const exec = Promise.promisify(childProcess.exec);
+const exec = Promise.promisify(childProcess.execFile);
 
 module.exports = function copyModules(projectPath, moduleNames, dest) {
+  // No dependencies, just return, so that npm install would not fail.
+  if (moduleNames.length === 0) {
+    return Promise.resolve();
+  }
+
   const pkg = require(path.join(projectPath, 'package.json'));
   const modulesAndVersions = moduleNames.map(moduleName => {
     const moduleVersion = pkg.dependencies[moduleName];
+
+    // If no module version was found, throw an error
+    if (!moduleVersion) {
+      throw new Error(`Error: Could not find module ${moduleName} in package.json!`);
+    }
+
     return `${moduleName}@${moduleVersion}`;
   });
-  const opts = {
-    cwd: path.join(dest)
-  };
-  const installString = modulesAndVersions.join(' ');
+  const opts = { cwd: path.join(dest), env: process.env };
+  const args = ['install', '--production'].concat(modulesAndVersions);
 
   // Run 'npm install' on each module to get a full set of dependencies,
   // not just the directly copied ones.
-  return exec(`npm install --production ${installString}`, opts);
+  return exec('npm', args, opts);
 };


### PR DESCRIPTION
NPM 3.0 prunes the node_modules graphs heavily, resulting in having the externals with partial dependency graphs.

Instead of just copying the pruned module paths, 'npm install --production' for each external module seems to solve the problem.

I created this in parallel of resolving problems with a largeish (40+ functions) code base, and it resolved the bundling problems I had earlier.
